### PR TITLE
Move stapling up

### DIFF
--- a/.github/scripts/signmacos.sh
+++ b/.github/scripts/signmacos.sh
@@ -59,14 +59,12 @@ notarization_output=$(
         --wait 2>&1)
 
 if [ $? -eq 0 ]; then
-    # Extract the operation ID from the output
+    echo "Notarization succeeded."
     echo $notarization_output
+    xcrun stapler staple "${dmg}"
     exit 0
   else
     echo "Notarization failed. Error: $notarization_output"
     exit 1
   fi
 fi
-
-# staple
-xcrun stapler staple "${dmg}"


### PR DESCRIPTION
Weird that the last build crashed, I queried the notarization logs and got:

```
Successfully received submission info
  createdDate: 2024-11-06T18:48:22.826Z
  id: 12784b02-c49b-4aee-81ab-1a1da3525c86
  name: LegendsViewer 1.0.dmg
  status: In Progress
```

Which seems ok?

Maybe running it again will fix it? It also looks like we exited too early and didn't "staple" the dmg