### PR TITLE
Try to add more stuff to the plist

### DIFF
--- a/.github/scripts/LegendsViewer.app/Contents/Info.plist
+++ b/.github/scripts/LegendsViewer.app/Contents/Info.plist
@@ -12,5 +12,11 @@
     <string>Icon</string>
     <key>CFBundleExecutable</key>
     <string>LegendsViewer</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.kromtec.legendsviewer-next</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>10.12</string>
 </dict>
 </plist>


### PR DESCRIPTION
More ceremonies for apple, because I noticed:

```
spctl --assess -vv /Applications/LegendsViewer.app
/Applications/LegendsViewer.app: rejected (the code is valid but does not seem to be an app)
origin=Developer ID Application: Koen Schmeets (8X77K9NDG3)
```

And the internet says it probably has to do with the missing APPL thingy in the plist...