### PR TITLE
Add storage and retrieval of the last used directory

### DIFF
--- a/LegendsViewer.Frontend/legends-viewer-frontend/src/stores/fileSystemStore.ts
+++ b/LegendsViewer.Frontend/legends-viewer-frontend/src/stores/fileSystemStore.ts
@@ -4,6 +4,8 @@ import { components } from '../generated/api-schema'; // Import from the OpenAPI
 
 export type FilesAndSubdirectories = components['schemas']['FilesAndSubdirectoriesDto'];
 
+export const dfDirectoryStorageKey = 'df-directory'
+
 export const useFileSystemStore = defineStore('fileSystem', {
   state: () => ({
     filesAndSubdirectories: {} as FilesAndSubdirectories,
@@ -68,13 +70,22 @@ export const useFileSystemStore = defineStore('fileSystem', {
       }
     },
 
-    async getRoot() {
+    async initialize() {
       // Set loading state to true
       this.loading = true;
 
       try {
+        // Fetch from the stored path if there is one, else filesystem root
+        const storedPath = localStorage.getItem(dfDirectoryStorageKey)
         // Fetch directory info from the backend
-        const { data, error } = await client.GET('/api/FileSystem');
+        // @ts-ignore
+        const { data, error } = await client.GET(`/api/FileSystem/{path}`, {
+          params: {
+            path : {
+              path: storedPath ? encodeURIComponent(storedPath) : ""
+            }
+          }
+        });
 
         if (error) {
           console.error(error);

--- a/LegendsViewer.Frontend/legends-viewer-frontend/src/views/WorldOverview.vue
+++ b/LegendsViewer.Frontend/legends-viewer-frontend/src/views/WorldOverview.vue
@@ -1,12 +1,24 @@
+<!--suppress ALL -->
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import {computed, onUnmounted, ref} from 'vue';
 import { useBookmarkStore } from '../stores/bookmarkStore';
-import { useFileSystemStore } from '../stores/fileSystemStore';
+import {dfDirectoryStorageKey, useFileSystemStore} from '../stores/fileSystemStore';
 
 const bookmarkStore = useBookmarkStore()
 const fileSystemStore = useFileSystemStore()
 bookmarkStore.getAll()
-fileSystemStore.getRoot();
+fileSystemStore.initialize();
+
+const unsubscribe = fileSystemStore.$subscribe((_, state) => {
+  const newStateCurrentDirectory = state.filesAndSubdirectories.currentDirectory
+  if (newStateCurrentDirectory) {
+    localStorage.setItem(dfDirectoryStorageKey, newStateCurrentDirectory);
+  }
+})
+
+onUnmounted(() => {
+  unsubscribe()
+})
 
 const fileName = ref<string>('')
 


### PR DESCRIPTION
Uses browser local storage to track the directory last used when selecting worlds and has the fileSystemStore load that directory if it is present - otherwise it falls back to the old behavior of loading root dir.