### PR TITLE
Always open web browser in non-developer environment

### DIFF
--- a/LegendsViewer.Backend/Program.cs
+++ b/LegendsViewer.Backend/Program.cs
@@ -6,6 +6,7 @@ using LegendsViewer.Backend.Legends.Interfaces;
 using LegendsViewer.Backend.Legends.Maps;
 using LegendsViewer.Backend.Logging;
 using LegendsViewer.Frontend;
+using Microsoft.AspNetCore.Connections;
 using Microsoft.Extensions.Logging.Console;
 using System.Text;
 using System.Text.Json.Serialization;
@@ -77,11 +78,21 @@ public class Program
 
         _ = WebAppStaticServer.RunAsync();
 
+        var openBrowser = Task.Delay(0);
         if (!app.Environment.IsDevelopment())
         {
-            _ = WebAppStaticServer.OpenPageInBrowserAsync();
+            openBrowser = WebAppStaticServer.OpenPageInBrowserAsync();
         }
 
-        app.Run();
+        try
+        {
+            app.Run();
+        }
+        catch (IOException exception) when (exception.InnerException is AddressInUseException)
+        {
+            Console.WriteLine($"Address already in use: {BackendUrl}");
+            Console.WriteLine("Skipping backend server.");
+            Task.WaitAll(openBrowser);
+        }
     }
 }

--- a/LegendsViewer.Backend/Program.cs
+++ b/LegendsViewer.Backend/Program.cs
@@ -15,6 +15,8 @@ namespace LegendsViewer.Backend;
 public class Program
 {
     private const string AllowAllOriginsPolicy = "AllowAllOrigins";
+    public const uint BackendPort = 5054;
+    public static readonly string BackendUrl = $"http://localhost:{BackendPort}";
 
     public static void Main(string[] args)
     {
@@ -33,7 +35,7 @@ public class Program
             serverOptions.Limits.KeepAliveTimeout = TimeSpan.FromMinutes(5);
             serverOptions.Limits.RequestHeadersTimeout = TimeSpan.FromMinutes(5);
         })
-        .UseUrls("http://localhost:5054");
+        .UseUrls(BackendUrl);
 
         builder.Services.AddSingleton<IWorld, World>();
         builder.Services.AddSingleton<IWorldMapImageGenerator, WorldMapImageGenerator>();

--- a/LegendsViewer.Frontend/WebAppStaticServer.cs
+++ b/LegendsViewer.Frontend/WebAppStaticServer.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using Microsoft.AspNetCore.Connections;
+using System.Diagnostics;
 
 namespace LegendsViewer.Frontend;
 
@@ -19,7 +20,16 @@ public static class WebAppStaticServer
         app.UseDefaultFiles(new DefaultFilesOptions { DefaultFileNames = ["index.html"] });
         app.UseStaticFiles();
         app.MapFallbackToFile("index.html");
-        await app.RunAsync($"http://*:{WebAppPort}");
+
+        try
+        {
+            await app.RunAsync($"http://*:{WebAppPort}");
+        }
+        catch (IOException exception) when (exception.InnerException is AddressInUseException)
+        {
+            Console.WriteLine($"Address already in use: {WebAppUrl}");
+            Console.WriteLine("Skipping static server.");
+        }
     }
 
     public static async Task OpenPageInBrowserAsync()

--- a/LegendsViewer.Frontend/WebAppStaticServer.cs
+++ b/LegendsViewer.Frontend/WebAppStaticServer.cs
@@ -37,7 +37,7 @@ public static class WebAppStaticServer
         await Task.Delay(200);
         try
         {
-            Process.Start(new ProcessStartInfo(WebAppUrl) { UseShellExecute = true });
+            Process.Start(new ProcessStartInfo(WebAppUrl) { UseShellExecute = true })?.WaitForExit();
         }
         catch
         {


### PR DESCRIPTION
## What

TLDR; This makes the backend always open the web browser in release builds.

It does this by catching `IOException`s when they are `AddressInUseException`s, and awaiting `WebAppStaticServer.OpenPageInBrowserAsync()` in the case of the backend server. It does not run if the app environment is a development server, as before. This patchset also exposes the `BackendPort` and the `BackendUrl` similar to how the static frontend server does.

Example log:
```log
Address already in use: http://localhost:8081
Skipping static server.
Hosting failed to start
Address already in use: http://localhost:5054
Skipping backend server.
(objectpath '/org/freedesktop/portal/desktop/request/1_192/t',)  // opens web browser

// exits
```

## Why

TLDR; This makes the app more user-friendly to use when launched as a desktop app.

A common use case for an installed WebApp on a desktop is to click the application launcher, do whatever, then close the browser tab. The user then might expect to be able to open the WebApp with the same application launcher again. Before these patches, it would just fail to launch. It would be up to the user to manually open the browser tab to localhost:8081. With these patches, the app will open the browser to the already running app instance, then exit. In the best case, the user continues using the app as usual. In the worse case, the user realizes they have something else running on port 8081, and fixes it.

This still does not handle the case where only the backend server fails because the port is bound to some other server. In that situation, the web app would open but would not function correctly. This could be fixed with a handshake between the frontend and the backend when the frontend initializes, if desired, but is beyond the scope of this pull request.

## Tested?

Yes. I am using the patched version right now :)