### PR TITLE
Better filesystem handling

### DIFF
--- a/LegendsViewer.Backend/Controllers/FileSystemController.cs
+++ b/LegendsViewer.Backend/Controllers/FileSystemController.cs
@@ -12,7 +12,7 @@ public class FileSystemController : ControllerBase
     [ProducesResponseType<FilesAndSubdirectoriesDto>(StatusCodes.Status200OK)]
     public ActionResult<FilesAndSubdirectoriesDto> Get()
     {
-        return Ok(GetRootInformation());
+        return Ok(GetHomeInformation());
     }
 
     [HttpGet("{encodedPath}")]
@@ -20,23 +20,31 @@ public class FileSystemController : ControllerBase
     public ActionResult<FilesAndSubdirectoriesDto> Get([FromRoute] string encodedPath)
     {
         var path = HttpUtility.UrlDecode(encodedPath);
-        if (!Path.Exists(path) && !Directory.Exists(path))
+
+        if (path == "mounts")
         {
-            return Ok(GetRootInformation());
+            return Ok(GetMountsInformation());
         }
-        string directoryName = Directory.GetCurrentDirectory();
+
+        if (!Path.Exists(path))
+        {
+            return Ok(GetHomeInformation());
+        }
+
+        string directoryName;
         if (Directory.Exists(path))
         {
             directoryName = path;
         }
-        else if (Path.Exists(path))
+        else
         {
             directoryName = Path.GetDirectoryName(path) ?? Directory.GetCurrentDirectory();
         }
+
         var response = new FilesAndSubdirectoriesDto
         {
             CurrentDirectory = directoryName,
-            ParentDirectory = Directory.GetParent(directoryName)?.FullName,
+            ParentDirectory = Directory.GetParent(directoryName)?.FullName ?? "mounts",
             Subdirectories = Directory.GetDirectories(directoryName)
                 .Select(subDirectoryPath => Path.GetRelativePath(directoryName, subDirectoryPath))
                 .Where(IsNotUnixHiddenPath)
@@ -48,6 +56,7 @@ public class FileSystemController : ControllerBase
                 .Order()
                 .ToArray()
         };
+
         return Ok(response);
     }
 
@@ -66,40 +75,42 @@ public class FileSystemController : ControllerBase
         return Get(fullPath);
     }
 
-    private static FilesAndSubdirectoriesDto GetRootInformation()
+    private static FilesAndSubdirectoriesDto GetMountsInformation()
     {
-        if (OperatingSystem.IsWindows())
+        // GetLogicalDrives will also get mount points on Unix/MacOS: see
+        // https://learn.microsoft.com/en-us/dotnet/api/system.io.directory.getlogicaldrives#remarks
+        var logicalDrives = Directory.GetLogicalDrives();
+        return new FilesAndSubdirectoriesDto
         {
-            // Windows: return logical drives (C:\, D:\, etc.)
-            var logicalDrives = Directory.GetLogicalDrives();
-            return new FilesAndSubdirectoriesDto
-            {
-                CurrentDirectory = Path.DirectorySeparatorChar.ToString(),
-                ParentDirectory = null,
-                Subdirectories = logicalDrives,
-                Files = Array.Empty<string>()
-            };
-        }
-        else
+            CurrentDirectory = Path.DirectorySeparatorChar.ToString(),
+            ParentDirectory = null,
+            Subdirectories = logicalDrives.Where(IsNotUnixHiddenPath)
+                .Order() // sort alphabetically
+                .ToArray(),
+            Files = Array.Empty<string>()
+        };
+    }
+
+    private static FilesAndSubdirectoriesDto GetHomeInformation()
+    {
+        var homePath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var homeDir = new DirectoryInfo(homePath);
+
+        return new FilesAndSubdirectoriesDto
         {
-            // Unix-like systems (Linux, macOS): start from root directory
-            var rootDir = new DirectoryInfo("/");
-            return new FilesAndSubdirectoriesDto
-            {
-                CurrentDirectory = "/",
-                ParentDirectory = null,
-                Subdirectories = rootDir.GetDirectories()
-                    .Select(d => d.FullName)
-                    .Where(IsNotUnixHiddenPath)
-                    .Order() // sort alphabetically
-                    .ToArray(),
-                Files = rootDir.GetFiles()
-                    .Select(f => f.FullName)
-                    .Where(IsNotUnixHiddenPath)
-                    .Order()
-                    .ToArray()
-            };
-        }
+            CurrentDirectory = homePath,
+            ParentDirectory = Directory.GetParent(homePath)?.FullName,
+            Subdirectories = homeDir.GetDirectories()
+                .Select(d => d.Name)
+                .Where(IsNotUnixHiddenPath)
+                .Order() // sort alphabetically
+                .ToArray(),
+            Files = homeDir.GetFiles()
+                .Select(f => f.Name)
+                .Where(IsNotUnixHiddenPath)
+                .Order()
+                .ToArray()
+        };
     }
 
     private static bool IsNotUnixHiddenPath(string path)

--- a/LegendsViewer.Backend/Controllers/FileSystemController.cs
+++ b/LegendsViewer.Backend/Controllers/FileSystemController.cs
@@ -39,11 +39,12 @@ public class FileSystemController : ControllerBase
             ParentDirectory = Directory.GetParent(directoryName)?.FullName,
             Subdirectories = Directory.GetDirectories(directoryName)
                 .Select(subDirectoryPath => Path.GetRelativePath(directoryName, subDirectoryPath))
-                .Where(f => !f.StartsWith('.')) // remove hidden directories
+                .Where(IsNotUnixHiddenPath)
                 .Order() // sort alphabetically
                 .ToArray(),
             Files = Directory.GetFiles(directoryName, $"*{BookmarkController.FileIdentifierLegendsXml}")
                 .Select(f => Path.GetFileName(f) ?? "")
+                .Where(IsNotUnixHiddenPath)
                 .Order()
                 .ToArray()
         };
@@ -89,14 +90,21 @@ public class FileSystemController : ControllerBase
                 ParentDirectory = null,
                 Subdirectories = rootDir.GetDirectories()
                     .Select(d => d.FullName)
-                    .Where(d => !d.StartsWith('.')) // remove hidden directories
+                    .Where(IsNotUnixHiddenPath)
                     .Order() // sort alphabetically
                     .ToArray(),
                 Files = rootDir.GetFiles()
                     .Select(f => f.FullName)
+                    .Where(IsNotUnixHiddenPath)
                     .Order()
                     .ToArray()
             };
         }
+    }
+
+    private static bool IsNotUnixHiddenPath(string path)
+    {
+        // Hide all '.' paths, except steam path
+        return !(path.StartsWith('.') && path != ".steam");
     }
 }

--- a/LegendsViewer.Frontend/legends-viewer-frontend/src/views/WorldOverview.vue
+++ b/LegendsViewer.Frontend/legends-viewer-frontend/src/views/WorldOverview.vue
@@ -143,7 +143,7 @@ const closeSnackbar = () => {
 
                   <v-list density="compact" height="220" scrollable>
                     <v-list-subheader>Directories</v-list-subheader>
-                    <v-list-item v-if="fileSystemStore.filesAndSubdirectories.currentDirectory != '/'"
+                    <v-list-item
                       @click="fileSystemStore.loadDirectory(fileSystemStore.filesAndSubdirectories.parentDirectory ?? '/')"
                       color="primary" variant="plain">
                       <template v-slot:prepend>


### PR DESCRIPTION
Closes #26 

This patch set adds various improvements to the file picker.
- .steam folder is no longer filtered so accessing the Steam premium Dwarf Fortress files is easier
- platform specific backend logic is unified
- First launch of Legends Viewer (or missing paths) will open to home directory on both Windows and Unix
- Unix now has potentially easier access to mounted filesystems such as usb drives or external Steam libraries (although this will depend on the Unix/personal setup).

Please let me know if there are any issues with this as these changes are a bit more invasive. I did test this on NixOS Linux and with Wine for Windows.

The biggest user-facing change is that Windows no longer will open to the drives by default, instead the user must click ".." until they get to the top level. But I think this is relatively intuitive. The most recent folder location will still be remembered by the browser as before.