### PR TITLE
Use less busy ports

### DIFF
--- a/LegendsViewer.Backend/LegendsViewer.Backend.http
+++ b/LegendsViewer.Backend/LegendsViewer.Backend.http
@@ -1,4 +1,4 @@
-@LegendsViewer.Backend_HostAddress = http://localhost:5054
+@LegendsViewer.Backend_HostAddress = http://localhost:15421
 
 POST {{LegendsViewer.Backend_HostAddress}}/api/Bookmark/loadByFullPath
 Content-Type: application/json

--- a/LegendsViewer.Backend/Program.cs
+++ b/LegendsViewer.Backend/Program.cs
@@ -16,7 +16,7 @@ namespace LegendsViewer.Backend;
 public class Program
 {
     private const string AllowAllOriginsPolicy = "AllowAllOrigins";
-    public const uint BackendPort = 5054;
+    public const uint BackendPort = 15421;
     public static readonly string BackendUrl = $"http://localhost:{BackendPort}";
 
     public static void Main(string[] args)

--- a/LegendsViewer.Backend/Properties/launchSettings.json
+++ b/LegendsViewer.Backend/Properties/launchSettings.json
@@ -14,7 +14,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "http://localhost:5054",
+      "applicationUrl": "http://localhost:15421",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/LegendsViewer.Frontend/WebAppStaticServer.cs
+++ b/LegendsViewer.Frontend/WebAppStaticServer.cs
@@ -5,7 +5,7 @@ namespace LegendsViewer.Frontend;
 
 public static class WebAppStaticServer
 {
-    public const uint WebAppPort = 8081;
+    public const uint WebAppPort = 15422;
     public static readonly string WebAppUrl = $"http://localhost:{WebAppPort}";
 
     public static async Task RunAsync()

--- a/LegendsViewer.Frontend/legends-viewer-frontend/package.json
+++ b/LegendsViewer.Frontend/legends-viewer-frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vue-tsc -b && vite build",
     "preview": "vite preview",
-    "generate-api-schema": "npx openapi-typescript http://localhost:5054/swagger/v1/swagger.json -o ./src/generated/api-schema.d.ts"
+    "generate-api-schema": "npx openapi-typescript http://localhost:15421/swagger/v1/swagger.json -o ./src/generated/api-schema.d.ts"
   },
   "dependencies": {
     "chart.js": "^4.4.8",

--- a/LegendsViewer.Frontend/legends-viewer-frontend/src/apiClient.ts
+++ b/LegendsViewer.Frontend/legends-viewer-frontend/src/apiClient.ts
@@ -1,6 +1,6 @@
 import createClient from "openapi-fetch";
 import type { paths } from "./generated/api-schema";
 
-const client = createClient<paths>({ baseUrl: "http://localhost:5054/" });
+const client = createClient<paths>({ baseUrl: "http://localhost:15421/" });
 
 export default client;


### PR DESCRIPTION
Fixes #49
Fixes #63

## What

This pull request simply changes the ports of the frontend and backend. I grepped for the old ports, I am pretty sure I found all of the references. This may affect the development workflow.

Backend: 5054 -> 15421
Frontend: 8081 -> 15422

As stated in the commit:
Available ports were found with a combination of looking up https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers , searching "port NUMBER", and looking up the speedguide.net information on the port.

## Why

As explained in #49, 8081 and 5054 are commonly used ports in both production and development. Using those ports could easily cause compatibility issues with any other application that already uses them. The desired fix would be to have configurable ports, but a sensible default would be to use a less busy port.